### PR TITLE
少数场景中, 环境变量HOME 和 HOMEPATH 并不存在

### DIFF
--- a/auto_backup/backup_scheduler.py
+++ b/auto_backup/backup_scheduler.py
@@ -45,7 +45,7 @@ def execute(connector, method, *args):
             raise e
     return res
 
-addons_path = (os.environ.get('HOME') or os.environ.get('HOMEPATH')) + '/DBbackups'
+addons_path = '%s/DBbackups' % (os.environ.get('HOME','') or os.environ.get('HOMEPATH',''))
 
 class db_backup(models.Model):
     _name = 'db.backup'


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
例如 用 supervision 启动Odoo,  由于 HOME 和 HOMEPATH  变量都不存在, 使得 os.environ.get('HOME','') or os.environ.get('HOMEPATH','') 返回的值类型为 'NoneType' 与 str 类型 的字串 无法相加

给 get 方法一个默认值, 确保 方法返回的是  str 类型,  

提交前:
---
  File "/intoerp/ia_addons/auto_backup/backup_scheduler.py", line 48, in <module>
    addons_path = (os.environ.get('HOME') or os.environ.get('HOMEPATH')) + '/DBbackups'
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

提交后:
---


--
我确认贡献此代码版权给GoodERP项目

